### PR TITLE
[Fix] : nGrinder 테스트시 문제가 발생하여 GET 요청 RequestBody를 RequestParam으로

### DIFF
--- a/src/main/java/com/mdt/backend/controller/FileSearchController.java
+++ b/src/main/java/com/mdt/backend/controller/FileSearchController.java
@@ -10,8 +10,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "SEARCH_API", description = "해당 파일경로가 있는지 확인하기 위한 검색 API")
@@ -27,7 +29,7 @@ public class FileSearchController {
         + "파일 경로에 대한 입력을 하였을 경우 유사한 파일 경로에 대한 결과물을 제공합니다.")
     @Parameter(name = "filePath", description = "파일 경로에 관한 정보를 입력. 입력하지 않으면 전체 파일 경로를 반환")
     @GetMapping("/search")
-    public ResponseEntity<FileSearchResponseDto> searchFiles(@RequestBody(required = false) FileSearchRequestDto fileSearchRequestDto) {
+    public ResponseEntity<FileSearchResponseDto> searchFiles(@ModelAttribute FileSearchRequestDto fileSearchRequestDto) {
         List<String> searchedFiles = dbService.searchFiles(fileSearchRequestDto);
         return ResponseEntity.ok(new FileSearchResponseDto("파일 검색 성공", searchedFiles));
     }

--- a/src/main/java/com/mdt/backend/dto/FileSearchRequestDto.java
+++ b/src/main/java/com/mdt/backend/dto/FileSearchRequestDto.java
@@ -2,8 +2,10 @@ package com.mdt.backend.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class FileSearchRequestDto {
     private String fileName;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- ex) #이슈번호, #이슈번호
- #18 

### 🎋 작업중인 브랜치
- 작업 중인 브랜치를 알려주세요.

- feature/#18

### 💡 작업내용
- 작업 배경을 알려주세요.

- nGrinder로 인하여 부하 테스트 진행하였을때 GET 요청에 requestBody로 보내는 것이 불가능하여 requestParam으로 변경하였습니다.


### 🔑 주요 변경사항
- 주요 변경사항 목록을 알려주세요.

- requestParam으로 fileName 전달

### 🏞 스크린샷
스크린샷을 첨부해주세요.

<img width="445" alt="image" src="https://github.com/user-attachments/assets/3c239f27-4f90-48aa-859e-3ce948239d0a">


closes #18 
